### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,10 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tingyik90.snackprogressbar">
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
As a library, you don't need the application object. It causes build issues for us.